### PR TITLE
Track guessed player event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Futbol Guess Game
+
+This repository contains a simple game to guess the "Player of the Day". Google Analytics is used for anonymous usage tracking.
+
+## Analytics Events
+
+When a player is successfully guessed, the site emits the `jugador_encontrado` event. It includes the following parameters:
+
+- `intentos`: number of attempts used to guess the player.
+- `racha`: current streak of consecutive days guessing correctly.
+

--- a/main.js
+++ b/main.js
@@ -446,6 +446,10 @@ function mostrarResultadoFinal() {
   if (btnCompartir) {
     btnCompartir.addEventListener("click", manejarCompartir);
   }
+
+  if (typeof gtag === "function") {
+    gtag("event", "jugador_encontrado", { intentos: intentos.length, racha });
+  }
 }
 
 function ocultarInputsDeJuego() {


### PR DESCRIPTION
## Summary
- trigger a GA event `jugador_encontrado` when the player is guessed
- document analytics event in README

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68421a7e0980832b82dbfbb4962f52eb